### PR TITLE
refer to mirage module types modules by new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ ARP is an implementation of the address resolution protocol purely in OCaml.  It
 handles IPv4 protocol addresses and Ethernet hardware addresses only.
 
 A MirageOS
-[V1.ARP](https://github.com/mirage/mirage/blob/v2.9.0/types/V1.mli#L471)
+[Mirage_types.ARP](https://github.com/mirage/mirage/blob/v2.9.0/types/Mirage_types.mli#L471)
 implementation (using Lwt) is in the `mirage` subdirectory.
 
 Motivation for this implementation is [written up](https://hannes.nqsb.io/Posts/ARP).

--- a/mirage/arp.ml
+++ b/mirage/arp.ml
@@ -20,14 +20,14 @@ open Lwt.Infix
 
 let logsrc = Logs.Src.create "ARP" ~doc:"Mirage ARP handler"
 
-module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.MCLOCK) (Time : V1_LWT.TIME) = struct
+module Make (Ethif : Mirage_types_lwt.ETHIF) (Clock : Mirage_types.MCLOCK) (Time : Mirage_types_lwt.TIME) = struct
 
   type 'a io = 'a Lwt.t
   type ipaddr = Ipaddr.V4.t
   type macaddr = Macaddr.t
   type buffer = Cstruct.t
-  type repr = ((macaddr, V1.Arp.error) result Lwt.t * (macaddr, V1.Arp.error) result Lwt.u) Arp_handler.t
-  type error = V1.Arp.error
+  type repr = ((macaddr, Mirage_types.Arp.error) result Lwt.t * (macaddr, Mirage_types.Arp.error) result Lwt.u) Arp_handler.t
+  type error = Mirage_types.Arp.error
   type t = {
     mutable state : repr ;
     ethif : Ethif.t ;

--- a/mirage/arp.mli
+++ b/mirage/arp.mli
@@ -15,8 +15,8 @@
  *
  *)
 
-module Make (Ethif : V1_LWT.ETHIF) (Clock : V1.MCLOCK) (Time : V1_LWT.TIME) : sig
-  include V1_LWT.ARP
+module Make (Ethif : Mirage_types_lwt.ETHIF) (Clock : Mirage_types.MCLOCK) (Time : Mirage_types_lwt.TIME) : sig
+  include Mirage_types_lwt.ARP
 
   val connect : Ethif.t -> Clock.t -> t Lwt.t
 end


### PR DESCRIPTION
V1 is now Mirage_types, and V1_LWT is now Mirage_types_lwt, as of MirageOS version 3.0.0.